### PR TITLE
fix(ci): run ci jobs sequentially

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -36,6 +36,7 @@ jobs:
 
   test_and_coverage:
     name: Test And Code Coverage
+    needs: quality
  
     runs-on: ubuntu-latest
     
@@ -44,7 +45,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
-        mongodb-version: ['5.x']
+        mongodb-version: ['5.0']
 
     steps:
     - uses: actions/checkout@v3
@@ -62,13 +63,14 @@ jobs:
     - name: Store variables
       run: |
         touch ".env"
-        echo 'PORT=${{ secrets.PORT }}' >> .env
         echo 'MONGODB_URL=${{ secrets.MONGODB_URL }}' >> .env
         echo 'JWT_SECRET=${{ secrets.JWT_SECRET }}' >> .env
-        echo 'JWT_ACCESS_EXPIRATION_MINUTES=${{ secrets.JWT_ACCESS_EXPIRATION_MINUTES }}' >> .env
-        echo 'JWT_REFRESH_EXPIRATION_DAYS=${{ secrets.JWT_REFRESH_EXPIRATION_DAYS }}' >> .env
-        echo 'JWT_RESET_PASSWORD_EXPIRATION_MINUTES=${{ secrets.JWT_RESET_PASSWORD_EXPIRATION_MINUTES }}' >> .env
-        echo 'JWT_VERIFY_EMAIL_EXPIRATION_MINUTES=${{ secrets.JWT_VERIFY_EMAIL_EXPIRATION_MINUTES }}' >> .env
+        
+        echo 'JWT_ACCESS_EXPIRATION_MINUTES=30' >> .env
+        echo 'JWT_REFRESH_EXPIRATION_DAYS=30' >> .env
+        echo 'JWT_RESET_PASSWORD_EXPIRATION_MINUTES=10' >> .env
+        echo 'JWT_VERIFY_EMAIL_EXPIRATION_MINUTES=10' >> .env
+        
         echo 'SMTP_HOST=${{ secrets.SMTP_HOST }}' >> .env
         echo 'SMTP_PORT=${{ secrets.SMTP_PORT }}' >> .env
         echo 'SMTP_USERNAME=${{ secrets.SMTP_USERNAME }}' >> .env


### PR DESCRIPTION
- adding "needs" in test_and_coverage job (github action workflow) so the jobs can run sequentially
- changing mogodb version from 5.x to 5.0, the 5.x causing error because there no 5.x version
- removing port from .env and using number on JWT_ACCESS_EXPIRATION_MINUTESJWT_REFRESH_EXPIRATION_DAYS, JWT_RESET_PASSWORD_EXPIRATION_MINUTES, JWT_VERIFY_EMAIL_EXPIRATION_MINUTES